### PR TITLE
fix: unable to update installed app

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,6 +46,8 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
 
+	namespace "kt.qrcodekeeper"
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "kt.qrcodekeeper"


### PR DESCRIPTION
explicitly set android namespace to the same value as applicationId